### PR TITLE
Automatically set secure permissions on personal config files

### DIFF
--- a/dot
+++ b/dot
@@ -450,6 +450,8 @@ merge_personal_configs() {
             git-merge)
                 if merge_git_config "$personal" "$target"; then
                     ((merge_count++))
+                    # Set secure permissions on personal config
+                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to merge git config from ${personal#"$DOTFILES_DIR"/}"
                     ((failed_count++))
@@ -462,6 +464,8 @@ merge_personal_configs() {
                     cat "$personal"
                 } >> "$target" 2>/dev/null; then
                     ((merge_count++))
+                    # Set secure permissions on personal config
+                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to append personal config to ${target#"$DOTFILES_DIR"/}"
                     ((failed_count++))
@@ -470,6 +474,8 @@ merge_personal_configs() {
             yaml-replace|replace)
                 if cp "$personal" "$target" 2>/dev/null; then
                     ((merge_count++))
+                    # Set secure permissions on personal config
+                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to copy ${personal#"$DOTFILES_DIR"/} to ${target#"$DOTFILES_DIR"/}"
                     ((failed_count++))

--- a/dot
+++ b/dot
@@ -422,6 +422,22 @@ merge_git_config() {
     return 0
 }
 
+# Secure permissions on personal config file
+secure_personal_file() {
+    local personal="$1"
+    
+    if [[ ! -f "$personal" ]]; then
+        return 0
+    fi
+    
+    if ! chmod 600 "$personal" 2>/dev/null; then
+        log_warning "Failed to set secure permissions on ${personal#"$DOTFILES_DIR"/}"
+        return 1
+    fi
+    
+    return 0
+}
+
 # Merge personal configurations with templates (auto-discovered)
 merge_personal_configs() {
     log_info "Merging personal configurations..."
@@ -433,6 +449,9 @@ merge_personal_configs() {
     while IFS= read -r personal; do
         [[ -z "$personal" ]] && continue
         [[ ! -f "$personal" ]] && continue
+        
+        # Set secure permissions on personal file unconditionally
+        secure_personal_file "$personal"
         
         local target="${personal%.personal}"
         
@@ -450,8 +469,6 @@ merge_personal_configs() {
             git-merge)
                 if merge_git_config "$personal" "$target"; then
                     ((merge_count++))
-                    # Set secure permissions on personal config
-                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to merge git config from ${personal#"$DOTFILES_DIR"/}"
                     ((failed_count++))
@@ -464,8 +481,6 @@ merge_personal_configs() {
                     cat "$personal"
                 } >> "$target" 2>/dev/null; then
                     ((merge_count++))
-                    # Set secure permissions on personal config
-                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to append personal config to ${target#"$DOTFILES_DIR"/}"
                     ((failed_count++))
@@ -474,8 +489,6 @@ merge_personal_configs() {
             yaml-replace|replace)
                 if cp "$personal" "$target" 2>/dev/null; then
                     ((merge_count++))
-                    # Set secure permissions on personal config
-                    chmod 600 "$personal" 2>/dev/null || true
                 else
                     log_error "Failed to copy ${personal#"$DOTFILES_DIR"/} to ${target#"$DOTFILES_DIR"/}"
                     ((failed_count++))


### PR DESCRIPTION
Fixes #14

## Problem

Personal configuration files containing sensitive information were world-readable. Health check reported 4 files with insecure permissions.

## Solution

Automatically set `chmod 600` on all `.personal` files during merge:
- Applied to existing files immediately
- Added to `merge_personal_configs()` for all merge strategies (git-merge, yaml-append, yaml-replace)
- Ensures future personal configs are created with secure permissions

## Testing

Before:
```
-rw-rw-r-- gh/.config/gh/config.yml.personal
-rw-rw-r-- git/.gitconfig.personal
```

After:
```
-rw------- gh/.config/gh/config.yml.personal
-rw------- git/.gitconfig.personal
```

Health check now shows:
```
✓ gh/.config/gh/config.yml.personal has secure permissions
✓ git/.gitconfig.personal has secure permissions
```

## Benefits

- Prevents unauthorized access to sensitive configuration
- Follows security best practices
- Eliminates health check warnings
- Automatic - no manual intervention needed