### PR TITLE
Add convenient dotfiles management function with completion

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -119,3 +119,30 @@ fi
 
 # Custom aliases
 alias cursor='~/Applications/cursor.AppImage --no-sandbox'
+
+# Dotfiles management function
+d() {
+    local cmd="${1:-help}"
+    shift 2>/dev/null
+    
+    case "$cmd" in
+        h|health)      ~/.dotfiles/dot health "$@" ;;
+        v|validate)    ~/.dotfiles/dot validate "$@" ;;
+        u|update)      ~/.dotfiles/dot update "$@" ;;
+        ua|update-all) ~/.dotfiles/dot update-all "$@" ;;
+        s|status)      ~/.dotfiles/dot status "$@" ;;
+        b|backup)      ~/.dotfiles/dot backup "$@" ;;
+        c|clean)       ~/.dotfiles/dot clean "$@" ;;
+        i|install)     ~/.dotfiles/dot install "$@" ;;
+        cd)            builtin cd ~/.dotfiles || return ;;
+        *)             ~/.dotfiles/dot "$cmd" "$@" ;;
+    esac
+}
+
+# Bash completion for dotfiles function
+_d_completion_bash() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local commands="health validate update update-all status backup clean install uninstall cd"
+    mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
+}
+complete -F _d_completion_bash d

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -123,26 +123,26 @@ alias cursor='~/Applications/cursor.AppImage --no-sandbox'
 # Dotfiles management function
 d() {
     local cmd="${1:-help}"
-    shift 2>/dev/null
+    if (($#)); then shift; fi
     
     case "$cmd" in
-        h|health)      ~/.dotfiles/dot health "$@" ;;
-        v|validate)    ~/.dotfiles/dot validate "$@" ;;
-        u|update)      ~/.dotfiles/dot update "$@" ;;
-        ua|update-all) ~/.dotfiles/dot update-all "$@" ;;
-        s|status)      ~/.dotfiles/dot status "$@" ;;
-        b|backup)      ~/.dotfiles/dot backup "$@" ;;
-        c|clean)       ~/.dotfiles/dot clean "$@" ;;
-        i|install)     ~/.dotfiles/dot install "$@" ;;
-        cd)            builtin cd ~/.dotfiles || return ;;
-        *)             ~/.dotfiles/dot "$cmd" "$@" ;;
+        h|health)      "$HOME/.dotfiles/dot" health "$@" ;;
+        v|validate)    "$HOME/.dotfiles/dot" validate "$@" ;;
+        u|update)      "$HOME/.dotfiles/dot" update "$@" ;;
+        ua|update-all) "$HOME/.dotfiles/dot" update-all "$@" ;;
+        s|status)      "$HOME/.dotfiles/dot" status "$@" ;;
+        b|backup)      "$HOME/.dotfiles/dot" backup "$@" ;;
+        c|clean)       "$HOME/.dotfiles/dot" clean "$@" ;;
+        i|install)     "$HOME/.dotfiles/dot" install "$@" ;;
+        cd)            builtin cd "$HOME/.dotfiles" || return ;;
+        *)             "$HOME/.dotfiles/dot" "$cmd" "$@" ;;
     esac
 }
 
 # Bash completion for dotfiles function
 _d_completion_bash() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local commands="health validate update update-all status backup clean install uninstall cd"
+    local commands="h health v validate u update ua update-all s status b backup c clean i install uninstall cd"
     mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$cur")
 }
 complete -F _d_completion_bash d

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -133,19 +133,19 @@ alias cursor='~/Applications/cursor.AppImage --no-sandbox'
 # Dotfiles management function
 d() {
     local cmd="${1:-help}"
-    shift 2>/dev/null
+    if (($#)); then shift; fi
     
     case "$cmd" in
-        h|health)      ~/.dotfiles/dot health "$@" ;;
-        v|validate)    ~/.dotfiles/dot validate "$@" ;;
-        u|update)      ~/.dotfiles/dot update "$@" ;;
-        ua|update-all) ~/.dotfiles/dot update-all "$@" ;;
-        s|status)      ~/.dotfiles/dot status "$@" ;;
-        b|backup)      ~/.dotfiles/dot backup "$@" ;;
-        c|clean)       ~/.dotfiles/dot clean "$@" ;;
-        i|install)     ~/.dotfiles/dot install "$@" ;;
-        cd)            builtin cd ~/.dotfiles || return ;;
-        *)             ~/.dotfiles/dot "$cmd" "$@" ;;
+        h|health)      "$HOME/.dotfiles/dot" health "$@" ;;
+        v|validate)    "$HOME/.dotfiles/dot" validate "$@" ;;
+        u|update)      "$HOME/.dotfiles/dot" update "$@" ;;
+        ua|update-all) "$HOME/.dotfiles/dot" update-all "$@" ;;
+        s|status)      "$HOME/.dotfiles/dot" status "$@" ;;
+        b|backup)      "$HOME/.dotfiles/dot" backup "$@" ;;
+        c|clean)       "$HOME/.dotfiles/dot" clean "$@" ;;
+        i|install)     "$HOME/.dotfiles/dot" install "$@" ;;
+        cd)            builtin cd "$HOME/.dotfiles" || return ;;
+        *)             "$HOME/.dotfiles/dot" "$cmd" "$@" ;;
     esac
 }
 
@@ -153,13 +153,21 @@ d() {
 _d_completion() {
     local -a commands
     commands=(
+        'h:health - Run comprehensive health check'
         'health:Run comprehensive health check'
+        'v:validate - Validate installation'
         'validate:Validate installation'
+        'u:update - Update submodules'
         'update:Update submodules'
+        'ua:update-all - Update all configurations'
         'update-all:Update all configurations'
+        's:status - Show installation status'
         'status:Show installation status'
+        'b:backup - Create backup'
         'backup:Create backup'
+        'c:clean - Clean up old backups'
         'clean:Clean up old backups'
+        'i:install - Install dotfiles'
         'install:Install dotfiles'
         'uninstall:Remove dotfiles'
         'cd:Change to dotfiles directory'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -129,3 +129,41 @@ fi
 
 # Custom aliases
 alias cursor='~/Applications/cursor.AppImage --no-sandbox'
+
+# Dotfiles management function
+d() {
+    local cmd="${1:-help}"
+    shift 2>/dev/null
+    
+    case "$cmd" in
+        h|health)      ~/.dotfiles/dot health "$@" ;;
+        v|validate)    ~/.dotfiles/dot validate "$@" ;;
+        u|update)      ~/.dotfiles/dot update "$@" ;;
+        ua|update-all) ~/.dotfiles/dot update-all "$@" ;;
+        s|status)      ~/.dotfiles/dot status "$@" ;;
+        b|backup)      ~/.dotfiles/dot backup "$@" ;;
+        c|clean)       ~/.dotfiles/dot clean "$@" ;;
+        i|install)     ~/.dotfiles/dot install "$@" ;;
+        cd)            builtin cd ~/.dotfiles || return ;;
+        *)             ~/.dotfiles/dot "$cmd" "$@" ;;
+    esac
+}
+
+# Zsh completion for dotfiles function
+_d_completion() {
+    local -a commands
+    commands=(
+        'health:Run comprehensive health check'
+        'validate:Validate installation'
+        'update:Update submodules'
+        'update-all:Update all configurations'
+        'status:Show installation status'
+        'backup:Create backup'
+        'clean:Clean up old backups'
+        'install:Install dotfiles'
+        'uninstall:Remove dotfiles'
+        'cd:Change to dotfiles directory'
+    )
+    _describe 'dotfiles command' commands
+}
+compdef _d_completion d


### PR DESCRIPTION
Fixes #19

## Problem

Accessing dotfiles commands requires typing full paths or changing directories.

## Solution

Added `d` function for quick dotfiles access with tab completion.

## Usage

**Short aliases:**
```bash
d h         # ./dot health
d v         # ./dot validate  
d u         # ./dot update
d ua        # ./dot update-all
d s         # ./dot status
d b         # ./dot backup
d c         # ./dot clean
d i         # ./dot install
d cd        # cd ~/.dotfiles
```

**Full command names:**
```bash
d health
d validate
d update
```

**Pass-through:**
```bash
d --help     # ./dot --help
d status -v  # ./dot status -v
```

## Features

- **Ergonomic**: Short, memorable commands
- **Tab Completion**: Works in both zsh and bash
- **Flexible**: Supports short aliases, full names, and pass-through
- **Safe**: Uses `builtin cd` with error handling

## Implementation

- Added to both `zsh/.zshrc` and `bash/.bashrc`
- Zsh uses `_describe` for rich completion with descriptions
- Bash uses `mapfile` for safe completion
- Shellcheck compliant

## Benefits

- Faster workflow
- Reduced typing
- Better discoverability (tab completion)
- Consistent interface across shells