### PR TITLE
Add diff command to preview changes

### DIFF
--- a/dot
+++ b/dot
@@ -1283,9 +1283,8 @@ show_diff_preview() {
                 target=$(readlink "$home_path")
                 local expected_target="$DOTFILES_DIR/$package/$file"
                 
-                # Allow symlinks with alternative path formats (relative paths or different directory structures)
-                # Only warn if target matches neither the expected absolute path nor contains the dotfiles pattern
-                if [[ "$target" != "$expected_target" ]] && [[ "$target" != *"${DOTFILES_DIR}/${package}/${file}"* ]]; then
+                # Check if symlink points to our dotfiles (allows any path format - absolute, relative, etc.)
+                if [[ "$target" != *"${DOTFILES_DIR}/${package}/${file}"* ]]; then
                     echo -e "   ${YELLOW}${SYMBOL_WARNING}${NC} $file"
                     echo "      Current: symlink → $target"
                     echo "      Expected: symlink → $expected_target"
@@ -1301,7 +1300,7 @@ show_diff_preview() {
                         
                         # Show diff preview (first 25 lines)
                         local diff_output
-                        diff_output=$(diff -u "$dotfile_path" "$home_path" 2>/dev/null || true)
+                        diff_output=$(diff -u "$home_path" "$dotfile_path" 2>/dev/null || true)
                         
                         while IFS= read -r line; do
                             if [[ "$line" == -* ]]; then
@@ -1314,7 +1313,7 @@ show_diff_preview() {
                         done < <(echo "$diff_output" | head -25)
                         
                         local diff_lines
-                        diff_lines=$(echo "$diff_output" | wc -l)
+                        diff_lines=$(echo "$diff_output" | grep -c '^')
                         if [[ $diff_lines -gt 25 ]]; then
                             echo "      ... ($(( diff_lines - 25 )) more lines)"
                         fi


### PR DESCRIPTION
## Description

Resolves #35

Adds diff preview command to safely preview what changes would be made before applying them.

## Changes

### New Command: `./dot diff`

Shows what would change without actually applying changes:

- **New files** - Shows files that would be created as new symlinks (green)
- **Modified files** - Shows files with different content and displays diff preview (blue)
- **Wrong targets** - Shows symlinks pointing to wrong location (yellow)
- **Summary** - Count of each change type

Color-coded diff output:
- Red lines: Content removed
- Green lines: Content added
- Shows first 25 lines of each diff with "... N more lines" if truncated

### Implementation

- Added `show_diff_preview()` function
  - Iterates all packages and their files
  - Compares current state with repository state
  - Three change types: new, modified, wrong target
  - Shows unified diff with color coding
  - Limits preview to 25 lines per file for readability
  
- Updated command routing in `main()` and `parse_arguments()`
- Updated `is_valid_command()` pattern
- Updated `show_usage()` help text
- Enhanced shell completions (bash and zsh)
- Added `d|diff` alias in `d()` wrapper function

### Output Example

```
╭──────────────────────────────────────────────────────────╮
│  Dotfiles Diff Preview                                    │
╰──────────────────────────────────────────────────────────╯

∙ Comparing current state with dotfiles repository...

 File Changes ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   ✓ No changes detected - system matches repository

 Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

✓ System is up to date with repository
```

## Benefits

✅ Preview changes before applying  
✅ Understand what will be modified  
✅ Safer updates and installations  
✅ Better visibility into configuration drift  
✅ Educational - see what dotfiles do  
✅ Confidence in making changes  

## Use Cases

```bash
# Preview what install would do
./dot diff

# Check if local configs drifted from repo
./dot diff

# Preview before update
git pull
./dot diff  # See what changed
./dot install  # Apply if looks good
```

## Testing

- ✅ Smoke tests pass (12/12)
- ✅ Shellcheck passes
- ✅ Tested on current dotfiles (shows "no changes")
- ✅ Diff detection logic verified
- ✅ Completions include diff command

## Checklist

- [x] Linting passes
- [x] Smoke tests pass
- [x] Changes follow AGENTS.md guidelines
- [ ] CI passes
- [ ] Copilot review requested and approved