### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hamishmorgan/.dotfiles/security/code-scanning/5](https://github.com/hamishmorgan/.dotfiles/security/code-scanning/5)

To fix this problem, we must add an explicit `permissions` block specifying the minimal set of privileges required. The best practice is to set these permissions either at the root of the workflow (applying to all jobs that do not have their own `permissions` block), or per job. In this workflow, none of the jobs, including `test-summary`, appear to require elevated privileges (like write access to repo contents, issues, or pull-requests), as they only run shell scripts, summary echoing, or checks. Therefore, setting read-only permissions is sufficient and ideal for least privilege.

**Specifically:**  
- Add a `permissions:` block at the root of the workflow (just after the workflow `name:` and before `on:`) setting `contents: read` (which is the most typical minimal requirement for jobs that may need to read repo files during the checkout or summary steps).  
- If, upon review, a job needs more (e.g., `issues: write` or `pull-requests: write`), add that specifically to that job only. In this case, the minimal block is `permissions: contents: read`.  
- No additional imports or methods are needed.

**File/Region to change:**  
- Add `permissions:` at the top: after `name: CI` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
