### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,8 @@ jobs:
     name: BATS Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: lint
+    permissions:
+      contents: read
     strategy:
       fail-fast: false  # Run both even if one fails
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/hamishmorgan/.dotfiles/security/code-scanning/3](https://github.com/hamishmorgan/.dotfiles/security/code-scanning/3)

To fix the issue, you should add the `permissions` key either at the root level of the workflow or individually for each job. Root-level placement applies the restriction to all jobs unless they override it. Since CodeQL flagged the `bats-tests` job specifically, the minimum fix is to add a `permissions` block with the lowest necessary privileges to that job. The minimal recommended permissions for typical CI jobs are `contents: read`, which allows reading repository contents for actions like `checkout`, but prevents writing back to the repository. If jobs need to upload artifacts, this is covered by default, but you can add more granular permissions as required. For now, add `permissions: contents: read` under the `bats-tests:` job.

Change details:
- Add a `permissions:` block directly under the `bats-tests:` job (line 51).
- The block should specify `contents: read` as a baseline.

No imports or method definitions are necessary—just edit the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
