### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,6 +125,8 @@ jobs:
   # PLATFORM VALIDATION WITH OS MATRIX
   validate-platform:
     name: Full Validation (${{ matrix.name }})
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/hamishmorgan/.dotfiles/security/code-scanning/4](https://github.com/hamishmorgan/.dotfiles/security/code-scanning/4)

To fix this issue, add an explicit `permissions:` block to the `validate-platform` job, specifying the minimum required token permissions. In the overwhelming majority of test/build jobs, the minimum permission of `contents: read` is sufficient, as these jobs typically only need to check out code and do not push changes or interact with GitHub in a write capacity. The most precise fix is to add, under the `validate-platform:` job, the following block:

```yaml
permissions:
  contents: read
```

This should be placed just after the `name:` (or anywhere before the `steps:` block) within the job definition, on line 128 (since line 127 is `name:` and line 128 is `runs-on:`). No additional imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
