### PR TITLE
docs: document multi-machine configuration learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,38 @@ git checkout -- packages/bash/.bashrc packages/zsh/.zshrc
 Runtime profiles and branch-based strategies add unnecessary complexity for single-user
 dotfiles when tools forcibly modify config files daily.
 
+**Key learnings about auto-appending tools:**
+
+Based on investigation of Shopify's dev tools (`/opt/dev/dev.sh`, `tec agent`):
+
+- **No prevention mechanism**: Tools hardcode append to `~/.bashrc`, `~/.zshrc`, etc.
+- **No environment variables**: Cannot redirect where they append
+- **No sentinel markers**: Tools don't check for existing config before appending
+- **No configuration options**: Cannot disable auto-append behavior
+- **Daily+ frequency**: Some tools re-append after updates (varies by tool)
+- **Idempotent loading**: Tools use guards (e.g., `USING_DEV` env var) to prevent double-loading
+
+Design decision: Accept manageable git noise
+
+Given constraints (daily+ re-appends, frequent commits from work machine), evaluated:
+
+- Chezmoi migration (1-2 weeks effort, bidirectional sync, templating)
+- XDG launcher pattern (breaks stow model for shell configs)
+- Git assume-unchanged/skip-worktree (hidden state, easy to forget)
+- Two-repository overlay (complexity, doesn't solve appends)
+
+Chosen: Pre-add integrations + .local files + accept git noise
+
+Rationale:
+
+- Keeps stow (simple, proven)
+- Single branch (no rebasing)
+- Tools duplicate existing code (easy to identify)
+- Use `git add -p` to skip duplicates when staging
+- Small price for avoiding complex migrations
+
+Alternative: Migrate to chezmoi later if git noise becomes unmanageable.
+
 ## Dependencies
 
 ### Required Tools


### PR DESCRIPTION
## Summary

Documents comprehensive learnings from multi-machine dotfiles configuration
research and implementation.

## What This Documents

### Problem Analysis
- Investigation into Shopify tools auto-append behavior
- Analysis of /opt/dev/dev.sh and tec agent implementation
- Discovery that tools provide no prevention mechanisms

### Solution Research
Evaluated multiple approaches:
- Chezmoi migration (full tool change)
- XDG launcher pattern (breaks stow model)
- Git assume-unchanged/skip-worktree (hidden state)
- Two-repository overlay (complexity)
- Template-based generation

### Design Decision
Chose pragmatic approach: pre-add integrations + .local files + accept git noise

Rationale documented:
- Keeps stow (simple, proven)
- Single branch (no rebasing)
- Minimal migration effort
- Can evolve to chezmoi if needed

## Changes

- Add "Key learnings about auto-appending tools" section
- Document why tools cannot be prevented from appending
- Explain design decision rationale
- Note alternative (chezmoi) for future consideration

## Context

This documents the research and decisions from implementing:
- PR #107: Machine-specific .local file pattern
- PR #109: Consolidate .secret to .local files

These PRs solved the multi-machine configuration problem (issues #45, #102).

## Related

Closes #45
Closes #102

cc @hamishmorgan