### PR TITLE
Document pattern for managing mixed config+data directories

### DIFF
--- a/dot
+++ b/dot
@@ -149,12 +149,12 @@ get_package_files() {
         git)     echo ".gitconfig,.gitattributes,.gitignore-globals" ;;
         zsh)     echo ".zshrc,.zprofile,.oh-my-zsh" ;;
         tmux)    echo ".tmux.conf" ;;
-        gh)      echo ".config/gh" ;;
+        gh)      echo ".config/gh/config.yml,.config/gh/hosts.yml" ;;
         gnuplot) echo ".gnuplot" ;;
         bash)    echo ".bashrc,.bash_profile" ;;
-        fish)    echo ".config/fish" ;;
-        wezterm) echo ".config/wezterm" ;;
-        bat)     echo ".config/bat" ;;
+        fish)    echo ".config/fish/config.fish,.config/fish/config.osx.fish,.config/fish/config.linux.fish,.config/fish/config.local.fish.example,.config/fish/functions" ;;
+        wezterm) echo ".wezterm.lua" ;;
+        bat)     echo ".config/bat/config" ;;
         rust)    echo ".cargo/config.toml,.cargo/config.local.toml.example,.rustfmt.toml,.rustfmt.toml.example" ;;
         *)       echo "" ;;
     esac


### PR DESCRIPTION
## Summary

Documents the pattern for managing directories that contain both dotfiles-managed configs and user/runtime data.

## Background

Discovered while fixing the rust package (PR #122). The `.cargo/` directory contains:
- **Managed configs**: `config.toml`, `.rustfmt.toml`
- **User data**: `bin/`, `credentials.toml`, `env`, `registry/`

Initial implementation listed `.cargo` as a directory, which caused `backup_existing()` to `rm -rf ~/.cargo`, deleting all user data.

## The Pattern

**Problem:** Stow's tree folding + backup function's directory removal = data loss

**Solution:** List individual files instead of directory names in `get_package_files()`

**How it works:**
1. `--no-folding` in `.stowrc` prevents directory folding
2. Individual file paths in `get_package_files()` = file-level symlinks
3. `backup_existing()` only removes listed files, not entire directory
4. User data in same directory remains untouched

## Documentation Added

New section in AGENTS.md: "Mixed Config+Data Directories"

- Explains the pattern with examples
- Shows wrong vs correct implementation
- Lists when to apply this pattern
- Related to Cursor copy-sync pattern (different solution to similar problem)

## Related

- PR #122 - Rust package with fixed implementation
- Issue #104 - Cursor package (copy-sync solution)

This documentation prevents repeating the same mistake with other packages.