### PR TITLE
Fix package documentation inconsistencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ This repository contains dotfiles managed with GNU Stow. Files are organized int
 - **gnuplot**: GNU Plot configuration
 - **bash**: Bash shell configuration
 - **fish**: Fish shell configuration
+- **wezterm**: WezTerm terminal emulator configuration
 - **bat**: Bat syntax highlighter configuration
+- **rust**: Rust toolchain configuration
 
 Template-based secrets management separates public templates from private secret configurations.
 The `system` package is stowed first to ensure `.stow-global-ignore` is in place before other packages.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/).
 - Template-based secrets management
 - macOS and Linux support
 - Validation script for installation verification
-- Packages: git, zsh, tmux, gh, gnuplot, bash, fish
+- Packages: git, zsh, tmux, gh, gnuplot, bash, fish, wezterm, bat, rust
 - Oh My Zsh submodule
 - CI/CD validation with GitHub Actions
 

--- a/dot
+++ b/dot
@@ -3553,6 +3553,7 @@ list_packages() {
             fish)    description="Fish shell configuration" ;;
             wezterm) description="WezTerm terminal emulator" ;;
             bat)     description="Bat syntax highlighter" ;;
+            rust)    description="Rust toolchain configuration" ;;
             *)       description="Unknown package" ;;
         esac
 


### PR DESCRIPTION
## Summary

Fixes package documentation inconsistencies identified during project review.

## Issues Fixed

1. **Missing rust package description**: The `rust` package was missing from the description case statement in `list_packages()`, causing it to show 'Unknown package' in `./dot packages` output.

2. **Incomplete package lists in documentation**: 
   - README.md was missing `wezterm`, `bat`, and `rust` packages
   - AGENTS.md was missing `wezterm` and `rust` packages

## Changes

- Added `rust` package description to `list_packages()` function in `dot`
- Updated README.md package list to include all packages: git, zsh, tmux, gh, gnuplot, bash, fish, wezterm, bat, rust
- Updated AGENTS.md package list to include wezterm and rust

## Verification

- ✅ Linting passes
- ✅ Smoke tests pass
- ✅ All packages now consistently documented

## Testing

Run `./dot packages` to verify rust package now shows correct description instead of 'Unknown package'.