### PR TITLE
Fix git package update command targeting wrong file

### DIFF
--- a/packages/git/manifest.toml
+++ b/packages/git/manifest.toml
@@ -11,3 +11,4 @@ target = "~"
 [update]
 command = "dev/update-gitignore"
 args = ["file"]
+update_target = ".gitignore-globals"


### PR DESCRIPTION
## Problem

The git package update command was using the first file in the `files` array (`.gitconfig`) instead of the intended target (`.gitignore-globals`). This caused the update script to overwrite `.gitconfig` with gitignore content when running `./dot update`.

## Root Cause

When the `"file"` placeholder in the update command args is replaced, the code defaults to the first file in the `files` array if `update_target` is not specified. Since `.gitconfig` is listed first in the manifest, it was incorrectly selected as the update target.

## Solution

Added `update_target = ".gitignore-globals"` to the `[update]` section in `packages/git/manifest.toml` to explicitly specify which file should be updated.

## Testing

- ✅ Linting passes
- ✅ All tests pass (139 tests)
- ✅ Manifest parsing correctly identifies update_target

## Changes

- `packages/git/manifest.toml`: Added `update_target = ".gitignore-globals"` to `[update]` section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8fcfdfd2a5446f12dd5ed578210bcc791297667f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->