### PR TITLE
Replace cd with zoxide using aliases

### DIFF
--- a/packages/fish/.config/fish/conf.d/zoxide.fish
+++ b/packages/fish/.config/fish/conf.d/zoxide.fish
@@ -1,11 +1,11 @@
 # zoxide - smarter cd command
 # Tracks your most used directories and lets you jump to them
-if type -q zoxide
+if type -q zoxide && status is-interactive
     zoxide init fish | source
-    alias zi='zoxide query -i'  # Interactive selection
 
-    # Usage:
-    # z <dir>     - jump to directory
-    # zi          - interactive directory selection with fzf
-    # z -         - go back to previous directory
+    # Alias cd to z for smart navigation
+    alias cd='z'
+
+    # Alias cdi to zi for interactive selection
+    alias cdi='zi'
 end


### PR DESCRIPTION
## Summary

Simplifies zoxide integration by using aliases instead of complex wrapper functions, fixing infinite loop issues while maintaining smart directory navigation.

## Changes

- Replace wrapper functions with simple aliases
- Alias `cd` to `z` for smart directory navigation
- Alias `cdi` to `zi` for interactive directory selection
- Remove complex function wrappers that caused infinite loops
- Keep interactive check to preserve standard `cd` behavior in scripts

## How It Works

1. `zoxide init fish` runs first and saves Fish's original `cd` function as `__zoxide_cd_internal`
2. Our `alias cd='z'` creates a new `cd` function that calls `z`
3. Flow: `cd` → `z` → `__zoxide_z` → `__zoxide_cd` → `__zoxide_cd_internal` (original Fish `cd`) → `builtin cd`

This avoids recursion because `__zoxide_cd_internal` uses `builtin cd` directly.

## Benefits

- ✅ No infinite loops - avoids recursion issues
- ✅ Simple implementation - just two aliases
- ✅ Scripts unaffected - interactive check preserves standard `cd` in non-interactive shells
- ✅ Full zoxide features - smart navigation, history tracking, and interactive selection

## Testing

Please verify:
- `cd -` (previous directory)
- `cd` (no args, should go home)
- `cd some/path` (normal usage)
- Non-interactive scripts (should use standard `cd`)